### PR TITLE
feat(style): add StyleOptions for HTML document styling

### DIFF
--- a/src/litecharts/__init__.py
+++ b/src/litecharts/__init__.py
@@ -46,6 +46,7 @@ from .types import (
     PriceScaleOptions,
     RectangleOptions,
     SingleValueData,
+    StyleOptions,
     TimeScaleOptions,
     WatermarkOptions,
 )
@@ -94,6 +95,7 @@ __all__ = [
     "PriceScaleOptions",
     "RectangleOptions",
     "SingleValueData",
+    "StyleOptions",
     "TimeScaleOptions",
     "WatermarkOptions",
     "createChart",

--- a/src/litecharts/chart.py
+++ b/src/litecharts/chart.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
         OhlcInput,
         PaneOptions,
         SingleValueInput,
+        StyleOptions,
     )
 
 
@@ -203,15 +204,18 @@ class Chart:
 
         return pane.addSeries(seriesType, options)  # type: ignore[arg-type]
 
-    def toHtml(self) -> str:
+    def toHtml(self, style: StyleOptions | None = None) -> str:
         """Generate self-contained HTML for the chart.
+
+        Args:
+            style: Optional HTML document styling options.
 
         Returns:
             HTML string.
         """
         from .render import renderChart
 
-        return renderChart(self)
+        return renderChart(self, style)
 
     def toFragment(self) -> str:
         """Generate an HTML fragment for embedding in custom pages.
@@ -252,44 +256,56 @@ class Chart:
 
         return renderFragment(self)
 
-    def show(self) -> None:
+    def show(self, style: StyleOptions | None = None) -> None:
         """Display the chart.
 
         Auto-detects environment: uses Jupyter inline display if in a notebook,
         otherwise opens in a browser.
+
+        Args:
+            style: Optional HTML document styling options.
         """
         if _inJupyter():
-            self.showNotebook()
+            self.showNotebook(style)
         else:
-            self.showBrowser()
+            self.showBrowser(style)
 
-    def showNotebook(self) -> None:
-        """Display the chart inline in a Jupyter notebook."""
+    def showNotebook(self, style: StyleOptions | None = None) -> None:
+        """Display the chart inline in a Jupyter notebook.
+
+        Args:
+            style: Optional HTML document styling options.
+        """
         from IPython.display import HTML, display
 
-        display(HTML(self.toHtml()))  # type: ignore[no-untyped-call]
+        display(HTML(self.toHtml(style)))  # type: ignore[no-untyped-call]
 
-    def showBrowser(self) -> None:
-        """Open the chart in the default web browser."""
+    def showBrowser(self, style: StyleOptions | None = None) -> None:
+        """Open the chart in the default web browser.
+
+        Args:
+            style: Optional HTML document styling options.
+        """
         import tempfile
         import webbrowser
 
         with tempfile.NamedTemporaryFile(
             mode="w", suffix=".html", delete=False, encoding="utf-8"
         ) as f:
-            f.write(self.toHtml())
+            f.write(self.toHtml(style))
             temp_path = f.name
 
         webbrowser.open(f"file://{temp_path}")
 
-    def save(self, path: str | Path) -> None:
+    def save(self, path: str | Path, style: StyleOptions | None = None) -> None:
         """Save the chart to an HTML file.
 
         Args:
             path: File path to save to.
+            style: Optional HTML document styling options.
         """
         path = Path(path)
-        path.write_text(self.toHtml(), encoding="utf-8")
+        path.write_text(self.toHtml(style), encoding="utf-8")
 
 
 def createChart(options: ChartOptions | None = None) -> Chart:

--- a/src/litecharts/render.py
+++ b/src/litecharts/render.py
@@ -16,7 +16,7 @@ from .plugins.marker_tooltips import extractMarkerTooltips, renderTooltipJs
 if TYPE_CHECKING:
     from .chart import Chart
     from .series import BaseSeries
-    from .types import OhlcInput, SingleValueInput
+    from .types import OhlcInput, SingleValueInput, StyleOptions
 
 
 def _stripTooltipFromMarkers(
@@ -180,11 +180,12 @@ def renderFragment(chart: Chart) -> str:
 </script>"""
 
 
-def renderChart(chart: Chart) -> str:
+def renderChart(chart: Chart, style: StyleOptions | None = None) -> str:
     """Render a chart to self-contained HTML.
 
     Args:
         chart: The chart to render.
+        style: Optional HTML document styling options.
 
     Returns:
         HTML string.
@@ -226,7 +227,7 @@ def renderChart(chart: Chart) -> str:
     <style>
         body {{
             margin: 0;
-            padding: 20px;
+            padding: {style.get("padding", 20) if style else 20}px;
             background: #1e1e1e;
         }}
     </style>

--- a/src/litecharts/types.py
+++ b/src/litecharts/types.py
@@ -216,6 +216,17 @@ class ChartOptions(TypedDict, total=False):
     watermark: WatermarkOptions
 
 
+class StyleOptions(TypedDict, total=False):
+    """Options for HTML document styling in renderChart/toHtml.
+
+    These options control the surrounding HTML document styles,
+    not the LWC chart itself. Only applies to full HTML rendering
+    (toHtml), not fragments (toFragment).
+    """
+
+    padding: int
+
+
 class PriceLineOptions(TypedDict, total=False):
     """Options for price lines."""
 


### PR DESCRIPTION
Rework of #5 — moves padding config out of `ChartOptions` (which mirrors LWC's native options)  into a new `StyleOptions` TypedDict passed to `toHtml()`/`show()`/`save()`.
                                                                                                 
This keeps `ChartOptions` purely about LWC config and prevents non-LWC options from leaking into
the `createChart()` JS call.                                                                     
                                                                                                 
Usage:                              
```python                              
chart.toHtml(style={"padding": 10})
```