### PR TITLE
feat(chart): add fitContent option to auto-fit visible time range

### DIFF
--- a/src/litecharts/chart.py
+++ b/src/litecharts/chart.py
@@ -58,6 +58,7 @@ class Chart:
         self._options: ChartOptions = options.copy() if options else {}
         self._panes: list[Pane] = []
         self._defaultPane: Pane | None = None
+        self._fitContent: bool = False
 
     @property
     def id(self) -> str:
@@ -89,6 +90,21 @@ class Chart:
         if isinstance(result, int):
             return result
         return 600
+
+    @property
+    def shouldFitContent(self) -> bool:
+        """Return whether fitContent should be called on render."""
+        return self._fitContent
+
+    def fitContent(self) -> None:
+        """Fit all data into the visible time range on render.
+
+        Calls timeScale().fitContent() in the generated JS, which adjusts
+        the visible range to show all data points. Best for small/medium
+        datasets. For large datasets, the default behavior (anchored to
+        the right edge with reasonable bar spacing) may be preferable.
+        """
+        self._fitContent = True
 
     def _getDefaultPane(self) -> Pane:
         """Get or create the default pane."""

--- a/src/litecharts/render.py
+++ b/src/litecharts/render.py
@@ -145,6 +145,10 @@ def _renderChartInitScript(chart: Chart) -> str:
         if tooltips:
             jsLines.append(renderTooltipJs(chartVar, containerId, tooltips))
 
+    # Fit content to timescale if requested
+    if chart.shouldFitContent:
+        jsLines.append(f"{chartVar}.timeScale().fitContent();")
+
     return "\n    ".join(jsLines)
 
 


### PR DESCRIPTION
Rework of #4 — makes `fitContent()` opt-in rather than unconditional.                            
                                                   
Adds a `fitContent()` method to the `Chart` class that mirrors LWC's `chart.timeScale().fitContent()`. When called, the generated JS will fit all data into the visible time range.                                                                              
                                                 
This is opt-in because unconditionally fitting content is problematic for large datasets (e.g., 5 years of daily data would squash candles to be unreadable).

Usage:
```python
chart = createChart()
s = chart.addSeries(CandlestickSeries)
s.setData(data)
chart.fitContent()
chart.show()