### PR TITLE
feat(markers): add SeriesMarkersApi handle for independent marker groups

### DIFF
--- a/src/litecharts/__init__.py
+++ b/src/litecharts/__init__.py
@@ -11,6 +11,7 @@ from .series import (
     CandlestickSeries,
     HistogramSeries,
     LineSeries,
+    SeriesMarkersApi,
     createSeriesMarkers,
 )
 from .types import (
@@ -93,6 +94,7 @@ __all__ = [
     "PriceScaleMargins",
     "PriceScaleOptions",
     "RectangleOptions",
+    "SeriesMarkersApi",
     "SingleValueData",
     "TimeScaleOptions",
     "WatermarkOptions",

--- a/src/litecharts/render.py
+++ b/src/litecharts/render.py
@@ -56,10 +56,9 @@ def _renderSeriesJs(
         f"{seriesVar}.setData({dataJs});",
     ]
 
-    if series.markers:
-        # Strip tooltip field before sending to LWC (it's handled separately)
+    for group in series.markerGroups:
         markersForLwc = _stripTooltipFromMarkers(
-            cast(list[dict[str, object]], series.markers)
+            cast(list[dict[str, object]], group.markers())
         )
         markersJs = json.dumps(markersForLwc)
         lines.append(

--- a/tests/expected_hashes.json
+++ b/tests/expected_hashes.json
@@ -1,6 +1,7 @@
 {
   "area_series": "bc15b10dd4c87269",
   "chart_with_markers": "2f016e95b2504ce2",
+  "chart_with_multiple_marker_groups": "b556c2f98db31460",
   "chart_with_price_lines": "516a39cb5853b32a",
   "chart_with_rectangles": "dde9e870ff7ce779",
   "empty_chart": "a3ab9b06e462ea1f",

--- a/tests/test_fragment.py
+++ b/tests/test_fragment.py
@@ -118,7 +118,7 @@ class TestToFragment:
                     "position": "aboveBar",
                     "shape": "arrowDown",
                     "color": "#f44336",
-                    "tooltip": {"title": "Signal", "body": "Buy signal"},
+                    "tooltip": {"title": "Signal", "fields": {"Action": "Buy signal"}},
                 }
             ],
         )
@@ -133,10 +133,12 @@ class TestToFragment:
         pane1 = chart.addPane()
         pane1.addSeries(CandlestickSeries).setData(sample_ohlc_dicts)
         pane2 = chart.addPane()
-        pane2.addSeries(LineSeries).setData([
-            {"time": 1609459200, "value": 100.0},
-            {"time": 1609545600, "value": 110.0},
-        ])
+        pane2.addSeries(LineSeries).setData(
+            [
+                {"time": 1609459200, "value": 100.0},
+                {"time": 1609545600, "value": 110.0},
+            ]
+        )
         fragment = chart.toFragment()
         # Native panes don't need manual time sync
         assert "subscribeVisibleLogicalRangeChange" not in fragment
@@ -218,10 +220,12 @@ class TestFragmentIntegration:
         chart1.addSeries(CandlestickSeries).setData(sample_ohlc_dicts)
 
         chart2 = createChart({"width": 400, "height": 300})
-        chart2.addSeries(LineSeries).setData([
-            {"time": 1609459200, "value": 100.0},
-            {"time": 1609545600, "value": 110.0},
-        ])
+        chart2.addSeries(LineSeries).setData(
+            [
+                {"time": 1609459200, "value": 100.0},
+                {"time": 1609545600, "value": 110.0},
+            ]
+        )
 
         html = f"""<!DOCTYPE html>
 <html>

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -379,3 +379,57 @@ class TestHtmlOutputRegression:
 
         html = chart.toHtml()
         hash_checker("chart_with_rectangles", html)
+
+    def test_chart_with_multiple_marker_groups_html(
+        self,
+        sample_ohlc_dicts: list[DataMapping],
+        hash_checker: Callable[[str, str], None],
+    ) -> None:
+        """Chart with multiple independent marker groups HTML output is stable."""
+        chart = Chart()
+        chart._id = "chart_test0009"
+        pane = chart.addPane()
+        pane._id = "pane_test0009"
+        series = pane.addSeries(CandlestickSeries)
+        series._id = "series_test0009"
+        series.setData(sample_ohlc_dicts)
+
+        # First marker group: sell signals
+        createSeriesMarkers(
+            series,
+            [
+                {
+                    "time": 1609459200,
+                    "position": "aboveBar",
+                    "shape": "arrowDown",
+                    "color": "#f44336",
+                    "text": "Sell",
+                    "id": "sell-1",
+                    "tooltip": {
+                        "title": "Sell Signal",
+                        "fields": {"Price": "$105", "PnL": "+$10"},
+                    },
+                },
+            ],
+        )
+        # Second marker group: buy signals
+        createSeriesMarkers(
+            series,
+            [
+                {
+                    "time": 1609632000,
+                    "position": "belowBar",
+                    "shape": "arrowUp",
+                    "color": "#4caf50",
+                    "text": "Buy",
+                    "id": "buy-1",
+                    "tooltip": {
+                        "title": "Buy Signal",
+                        "fields": {"Price": "$115", "Size": "100"},
+                    },
+                },
+            ],
+        )
+
+        html = chart.toHtml()
+        hash_checker("chart_with_multiple_marker_groups", html)


### PR DESCRIPTION
This is a re-work of #3, more closely mirroring LWC's behavior 

## Summary                             
                                                                                                 
- Reworks createSeriesMarkers() to return a SeriesMarkersApi handle (mirroring LWC's
ISeriesMarkersPluginApi), so each call creates an independent marker group instead of replacing a
 single flat list                      
- Multiple createSeriesMarkers() calls on the same series now coexist — each group renders its
own LightweightCharts.createSeriesMarkers() JS call
- Handle exposes setMarkers(), markers(), and detach() for per-group management; detach() is
idempotent

```python
from litecharts import createChart, CandlestickSeries, createSeriesMarkers                       
                                                    
chart = createChart()                                                                            
series = chart.addSeries(CandlestickSeries)                                                      
series.setData(ohlcData)                                                                         

# Each call returns an independent handle
sells = createSeriesMarkers(series, [
    {"time": 1609459200, "position": "aboveBar", "shape": "arrowDown", "color": "#f44336",
"text": "Sell"},
])
buys = createSeriesMarkers(series, [
    {"time": 1609545600, "position": "belowBar", "shape": "arrowUp", "color": "#4caf50", "text":
"Buy"},
])

# Manage each group independently
sells.setMarkers([...])   # replace this group's markers
sells.markers()           # read back this group's markers
sells.detach()            # remove this group entirely

# Flattened view across all remaining groups
series.markers            # returns buys only (sells was detached)
```
